### PR TITLE
Upgrade java version to 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Otherwise, compilation fails due to missing lambda support:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project convolutionalSat: Compilation failure
[ERROR] /../convolutionalSAT/src/main/java/io/github/githubjakob/convolutionalSat/modules/Module.java:[180,93] lambda expressions are not supported in -source 1.7
[ERROR]   (use -source 8 or higher to enable lambda expressions)
```